### PR TITLE
Refactor: Move mainPanel, leftPanelOpen, and isLeftPanelPinned state …

### DIFF
--- a/BookVault.Frontend/src/components/book-reading-board/BookReadingBorad.jsx
+++ b/BookVault.Frontend/src/components/book-reading-board/BookReadingBorad.jsx
@@ -12,7 +12,9 @@ export default function BookReadingBorad() {
   const [loading, setLoading] = useState(true);
   const containerRef = useRef(null);
   const [bookWidth, setBookWidth] = useState(100); // in percent
-  const [isRightPanelOpen, setIsRightPanelOpen] = useState(false);
+  const [mainPanel, setMainPanel] = useState(null);
+  const [leftPanelOpen, setLeftPanelOpen] = useState(false);
+  const [isLeftPanelPinned, setIsLeftPanelPinned] = useState(false);
 
   // Load existing book data
   useEffect(() => {
@@ -64,7 +66,17 @@ export default function BookReadingBorad() {
   return (
     <div className={styles.container} ref={containerRef}>
       <div className={styles.wrapper} style={{ width: `${100 - bookWidth}%` }}>
-        <SideButtonsWrapper bookWidth={bookWidth} setBookWidth={setBookWidth} containerRef={containerRef} setIsRightPanelOpen={setIsRightPanelOpen} />
+        <SideButtonsWrapper
+          bookWidth={bookWidth}
+          setBookWidth={setBookWidth}
+          containerRef={containerRef}
+          mainPanel={mainPanel}
+          setMainPanel={setMainPanel}
+          leftPanelOpen={leftPanelOpen}
+          setLeftPanelOpen={setLeftPanelOpen}
+          isLeftPanelPinned={isLeftPanelPinned}
+          setIsLeftPanelPinned={setIsLeftPanelPinned}
+        />
       </div>
       <div className={styles.book} style={{ width: `${bookWidth}%` }}>
         <FlipBook isRightPanelOpen={isRightPanelOpen}/>

--- a/BookVault.Frontend/src/components/side-button-wrapper/SideButtonWrapper.jsx
+++ b/BookVault.Frontend/src/components/side-button-wrapper/SideButtonWrapper.jsx
@@ -9,17 +9,24 @@ import { FaChartBar } from "react-icons/fa";
 const rightButtonData = ["Bookmarks", "Appearance", "Reading Style", "Statistics"];
 const leftButtonData = ["Notes"];
 
-export default function SideButtonsWrapper({bookWidth, setBookWidth, containerRef}) {
+export default function SideButtonsWrapper({
+  bookWidth,
+  setBookWidth,
+  containerRef,
+  mainPanel,
+  setMainPanel,
+  leftPanelOpen,
+  setLeftPanelOpen,
+  isLeftPanelPinned,
+  setIsLeftPanelPinned,
+}) {
   const [rightOffsets, setRightOffsets] = useState([]);
   const [leftOffsets, setLeftOffsets] = useState([]);
-  const [mainPanel, setMainPanel] = useState(null); // right or bottom panel
   const [isMainClosing, setIsMainClosing] = useState(false);
   const [isMainOpening, setIsMainOpening] = useState(false);
-  const [leftPanelOpen, setLeftPanelOpen] = useState(false);
   const [isLeftOpening, setIsLeftOpening] = useState(false);
   const [isLeftClosing, setIsLeftClosing] = useState(false);
   const [pendingPanel, setPendingPanel] = useState(null);   // Panel to open next after closing
-  const [isLeftPanlePinned, setLeftPanlePinned] = useState(false);
 
   const rightRefs = useRef([]);
   const leftRefs = useRef([]);


### PR DESCRIPTION
…to BookReadingBoard to improve state synchronization and prevent UI flickering during panel transitions