### PR TITLE
fix(bookmark-navigation): ensure FlipBook navigates even when the sam…

### DIFF
--- a/BookVault.Frontend/src/components/book-reading-board/BookReadingBorad.jsx
+++ b/BookVault.Frontend/src/components/book-reading-board/BookReadingBorad.jsx
@@ -25,6 +25,12 @@ export default function BookReadingBorad() {
     return (isRight || isBottom) && leftPanelOpen && isLeftPanelPinned;
   }, [mainPanel, leftPanelOpen, isLeftPanelPinned]);
 
+  // function to force re-trigger bookmark navigation
+  const handleBookmarkSelect = (pageNum) => {
+    setSelectedBookmarkedPageNumber(null); // Reset to trigger change
+    setTimeout(() => setSelectedBookmarkedPageNumber(pageNum), 0); // Set new page
+  };
+
   // Load existing book data
   useEffect(() => {
     const loadBookData = async () => {
@@ -85,7 +91,7 @@ export default function BookReadingBorad() {
           setLeftPanelOpen={setLeftPanelOpen}
           isLeftPanelPinned={isLeftPanelPinned}
           setIsLeftPanelPinned={setIsLeftPanelPinned}
-          onBookmarkSelect={setSelectedBookmarkedPageNumber}
+          onBookmarkSelect={handleBookmarkSelect}
         />
       </div>
       <div className={styles.book} style={{ width: `${bookWidth}%` }}>


### PR DESCRIPTION
…e bookmark is selected

- Added `handleBookmarkSelect` to reset `selectedBookmarkedPageNumber` before setting a new value.
- This forces the `useEffect` in FlipBook to re-trigger, allowing navigation to the same page multiple times.
- Fixes issue where double-clicking the same bookmark after a manual page flip would not navigate.